### PR TITLE
Updated the source name in the instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This will create a new VPC, and deploy Etleap and its associated resources insid
 
 ```
 module "etleap" {
-  source  = "app.terraform.io/etleap/etleap-vpc/aws"
+  source  = "etleap/etleap-vpc/aws"
   version = "1.0.0"
 
   region           = "us-east-1"


### PR DESCRIPTION
## Updated the source name in the instructions

This will allow `terraform init` to run without encountering 401 errors.
