### PR TITLE
Upgrade to MySQL 5.7 and add option to start/destroy app instance

### DIFF
--- a/alarms.tf
+++ b/alarms.tf
@@ -1,4 +1,6 @@
 resource "aws_cloudwatch_metric_alarm" "emr_cluster_running" {
+  count = var.app_available ? 1 : 0
+
   alarm_name          = "Etleap - ${var.deployment_id} - EMR Cluster Running"
   comparison_operator = "LessThanThreshold"
   evaluation_periods  = "3"
@@ -17,6 +19,8 @@ resource "aws_cloudwatch_metric_alarm" "emr_cluster_running" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "emr_hdfs_utilization" {
+  count = var.app_available ? 1 : 0
+
   alarm_name          = "Etleap - ${var.deployment_id} - 60% Disk EMR HDFS"
   comparison_operator = "GreaterThanThreshold"
   evaluation_periods  = "3"
@@ -34,6 +38,8 @@ resource "aws_cloudwatch_metric_alarm" "emr_hdfs_utilization" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "emr_unhealthy_nodes" {
+  count = var.app_available ? 1 : 0
+
   alarm_name          = "Etleap - ${var.deployment_id} - EMR Unhealthy Nodes"
   comparison_operator = "GreaterThanThreshold"
   evaluation_periods  = "3"
@@ -51,6 +57,8 @@ resource "aws_cloudwatch_metric_alarm" "emr_unhealthy_nodes" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "emr_missing_blocks" {
+  count = var.app_available ? 1 : 0
+
   alarm_name          = "Etleap - ${var.deployment_id} - EMR Missing Blocks"
   comparison_operator = "GreaterThanThreshold"
   evaluation_periods  = "3"
@@ -119,13 +127,15 @@ resource "aws_cloudwatch_metric_alarm" "rds_freeable_memory" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "main_node_cpu" {
+  count = var.app_available ? 1 : 0
+
   alarm_name          = "Etleap - ${var.deployment_id} - Main Node 80% CPU"
   comparison_operator = "GreaterThanThreshold"
   evaluation_periods  = "3"
   metric_name         = "CPUUtilization"
   namespace           = "AWS/EC2"
   dimensions = {
-    InstanceId = module.main_app.instance_id
+    InstanceId = module.main_app[0].instance_id
   }
   period                    = "300"
   statistic                 = "Average"
@@ -136,7 +146,7 @@ resource "aws_cloudwatch_metric_alarm" "main_node_cpu" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "secondary_node_cpu" {
-  count               = var.ha_mode ? 1 : 0
+  count               = var.app_available && var.ha_mode ? 1 : 0
   alarm_name          = "Etleap - ${var.deployment_id} - Secondary Node 80% CPU"
   comparison_operator = "GreaterThanThreshold"
   evaluation_periods  = "3"
@@ -154,13 +164,15 @@ resource "aws_cloudwatch_metric_alarm" "secondary_node_cpu" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "main_app_disk_root" {
+  count = var.app_available ? 1 : 0
+
   alarm_name          = "Etleap - ${var.deployment_id} - Main Node 90% Disk Root"
   comparison_operator = "GreaterThanThreshold"
   evaluation_periods  = "1"
   metric_name         = "Disk"
   namespace           = "Etleap/EC2"
   dimensions = {
-    InstanceId = module.main_app.instance_id
+    InstanceId = module.main_app[0].instance_id
     Device     = "Root"
   }
   period                    = "60"
@@ -172,13 +184,15 @@ resource "aws_cloudwatch_metric_alarm" "main_app_disk_root" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "main_app_disk_docker" {
+  count = var.app_available ? 1 : 0
+
   alarm_name          = "Etleap - ${var.deployment_id} - Main Node 90% Disk Docker"
   comparison_operator = "GreaterThanThreshold"
   evaluation_periods  = "1"
   metric_name         = "Disk"
   namespace           = "Etleap/EC2"
   dimensions = {
-    InstanceId = module.main_app.instance_id
+    InstanceId = module.main_app[0].instance_id
     Device     = "Docker"
   }
   period                    = "60"
@@ -190,7 +204,7 @@ resource "aws_cloudwatch_metric_alarm" "main_app_disk_docker" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "secondary_app_disk_root" {
-  count               = var.ha_mode ? 1 : 0
+  count               = var.app_available && var.ha_mode ? 1 : 0
   alarm_name          = "Etleap - ${var.deployment_id} - Secondary Node 90% Disk Root"
   comparison_operator = "GreaterThanThreshold"
   evaluation_periods  = "1"
@@ -209,7 +223,7 @@ resource "aws_cloudwatch_metric_alarm" "secondary_app_disk_root" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "secondary_app_disk_docker" {
-  count               = var.ha_mode ? 1 : 0
+  count               = var.app_available && var.ha_mode ? 1 : 0
   alarm_name          = "Etleap - ${var.deployment_id} - HA Node 90% Disk Docker"
   comparison_operator = "GreaterThanThreshold"
   evaluation_periods  = "1"

--- a/app.tf
+++ b/app.tf
@@ -31,6 +31,8 @@ locals {
 }
 
 module "main_app" {
+  count = var.app_available ? 1 : 0
+
   depends_on = [
     aws_route.prod_public,
     aws_emr_cluster.emr
@@ -57,7 +59,8 @@ module "main_app" {
 }
 
 module "secondary_app" {
-  count = var.ha_mode ? 1 : 0
+  count = var.app_available && var.ha_mode ? 1 : 0
+
   depends_on = [
     aws_route.prod_public,
     aws_emr_cluster.emr
@@ -147,13 +150,14 @@ resource "aws_lb_listener" "app" {
 }
 
 resource "aws_lb_target_group_attachment" "main_app" {
+  count            = var.app_available ? 1 : 0
   target_group_arn = aws_lb_target_group.app.arn
-  target_id        = module.main_app.instance_id
+  target_id        = module.main_app[0].instance_id
   port             = 443
 }
 
 resource "aws_lb_target_group_attachment" "secondary_app" {
-  count            = var.ha_mode ? 1 : 0
+  count            = var.app_available && var.ha_mode ? 1 : 0
   target_group_arn = aws_lb_target_group.app.arn
   target_id        = module.secondary_app[0].instance_id
   port             = 443

--- a/outputs.tf
+++ b/outputs.tf
@@ -75,7 +75,7 @@ output "deployment_id" {
 }
 
 output "main_app_instance_id" {
-  value       = module.main_app.instance_id
+  value       = var.app_available ? module.main_app[0].instance_id : null
   description = "The instance ID of the main application instance."
 }
 

--- a/rds.tf
+++ b/rds.tf
@@ -3,13 +3,13 @@ resource "aws_db_instance" "db" {
   allocated_storage            = 500
   storage_type                 = "gp2"
   engine                       = "mysql"
-  engine_version               = "5.6.41"
+  engine_version               = "5.7.34"
   instance_class               = "db.m5.large"
   name                         = "EtleapDB"
   username                     = "root"
   password                     = module.db_root_password.secret_string
   db_subnet_group_name         = aws_db_subnet_group.db.name
-  parameter_group_name         = aws_db_parameter_group.mysql5-6-etleap.name
+  parameter_group_name         = aws_db_parameter_group.mysql5-7-etleap.name
   vpc_security_group_ids       = [aws_security_group.db.id]
   backup_retention_period      = var.rds_backup_retention_period
   auto_minor_version_upgrade   = false
@@ -19,6 +19,9 @@ resource "aws_db_instance" "db" {
   deletion_protection          = true
   performance_insights_enabled = true
   multi_az                     = var.ha_mode
+
+  allow_major_version_upgrade = var.rds_allow_major_version_upgrade
+  apply_immediately           = var.rds_allow_major_version_upgrade
 
   lifecycle {
     ignore_changes = [
@@ -40,10 +43,10 @@ resource "aws_db_subnet_group" "db" {
   }
 }
 
-resource "aws_db_parameter_group" "mysql5-6-etleap" {
-  name        = "etleap-mysql5-6-${random_id.deployment_random.hex}"
-  description = "MySQL 5.6 with Etleap modifications"
-  family      = "mysql5.6"
+resource "aws_db_parameter_group" "mysql5-7-etleap" {
+  name        = "etleap-mysql5-7-${random_id.deployment_random.hex}"
+  description = "MySQL 5.7 with Etleap modifications"
+  family      = "mysql5.7"
 
   parameter {
     name         = "max_allowed_packet"

--- a/variables.tf
+++ b/variables.tf
@@ -81,6 +81,11 @@ variable "app_hostname" {
   description = "The hostname where Etleap will be accessible from."
 }
 
+variable "app_available" {
+  default     = true
+  description = "Enable or disable to start or destroy the app instance."
+}
+
 variable "ha_mode" {
   default     = false
   description = "Enables High Availability mode. This will run two redundant Etleap instances in 2 availability zones, and set the RDS instace to \"multi-az\" mode."
@@ -247,6 +252,11 @@ variable "acm_certificate_arn" {
 variable "rds_backup_retention_period" {
   default     = 7
   description = "The number of days to retain the automated database snapshots. Defaults to 7 days."
+}
+
+variable "rds_allow_major_version_upgrade" {
+  default     = false
+  description = "Indicates that major version upgrades are allowed and if an update is required it will be applied immediately."
 }
 
 # here we are validating the VPC config is valid, and that we have 4 subnets if the user is specifying a VPC ID.


### PR DESCRIPTION
## Description of the change

Upgrade to MySQL 5.7 and optional variable to start/destroy app, to allow programatically updates

New options:
- **rds_allow_major_version_upgrade:** Indicates that major version upgrades are allowed and if an update is required it will be applied immediately
- **app_available:** Enable or disable to start or destroy the app instance. This allows the customer to stop the application before upgrading the RDS DB

## Type of change
- [x] Infrastructure change

## Related story in Pivotal

[terraform-aws-etleap-vpc with upgraded MySQL 5.7](https://www.pivotaltracker.com/story/show/179105166)

## Checklists

### Development

N/A

### Code review 

- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached.
- [] Reviews have been requested.
- [ ] Changes have been reviewed and accepted by at least one other engineer.
- [x] The Pivotal story has a link to this pull request.
