### PR TITLE
Fix mysql version to 5.6.41

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+
+.idea
+.terraform

--- a/rds.tf
+++ b/rds.tf
@@ -3,13 +3,13 @@ resource "aws_db_instance" "db" {
   allocated_storage            = 500
   storage_type                 = "gp2"
   engine                       = "mysql"
-  engine_version               = "5.7.34"
+  engine_version               = "5.6.41"
   instance_class               = "db.m5.large"
   name                         = "EtleapDB"
   username                     = "root"
   password                     = module.db_root_password.secret_string
   db_subnet_group_name         = aws_db_subnet_group.db.name
-  parameter_group_name         = aws_db_parameter_group.mysql5-7-etleap.name
+  parameter_group_name         = aws_db_parameter_group.mysql5-6-etleap.name
   vpc_security_group_ids       = [aws_security_group.db.id]
   backup_retention_period      = var.rds_backup_retention_period
   auto_minor_version_upgrade   = false
@@ -47,6 +47,102 @@ resource "aws_db_parameter_group" "mysql5-7-etleap" {
   name        = "etleap-mysql5-7-${random_id.deployment_random.hex}"
   description = "MySQL 5.7 with Etleap modifications"
   family      = "mysql5.7"
+
+  parameter {
+    name         = "max_allowed_packet"
+    value        = 546308096
+    apply_method = "pending-reboot"
+  }
+
+  parameter {
+    name         = "character-set-client-handshake"
+    value        = 0
+    apply_method = "pending-reboot"
+  }
+
+  parameter {
+    name         = "collation_server"
+    value        = "latin1_swedish_ci"
+    apply_method = "immediate"
+  }
+
+  parameter {
+    name         = "character_set_server"
+    value        = "latin1"
+    apply_method = "immediate"
+  }
+
+  parameter {
+    name         = "log_bin_trust_function_creators"
+    value        = 1
+    apply_method = "pending-reboot"
+  }
+
+  parameter {
+    name         = "binlog_format"
+    value        = "ROW"
+    apply_method = "immediate"
+  }
+
+  parameter {
+    name         = "innodb_lock_wait_timeout"
+    value        = 250
+    apply_method = "immediate"
+  }
+
+  parameter {
+    name         = "general_log"
+    value        = "0"
+    apply_method = "immediate"
+  }
+
+  parameter {
+    name         = "long_query_time"
+    value        = 0.05
+    apply_method = "immediate"
+  }
+
+  parameter {
+    name         = "slow_query_log"
+    value        = 1
+    apply_method = "immediate"
+  }
+
+  parameter {
+    name         = "log_warnings"
+    value        = 2
+    apply_method = "immediate"
+  }
+
+  parameter {
+    name         = "slow_query_log"
+    value        = 1
+    apply_method = "immediate"
+  }
+
+  parameter {
+    name         = "log_output"
+    value        = "file"
+    apply_method = "immediate"
+  }
+
+  parameter {
+    name         = "binlog_checksum"
+    value        = "none"
+    apply_method = "immediate"
+  }
+
+  parameter {
+    name         = "innodb_log_file_size"
+    value        = 5463080960 # 10x max_allowed_packet
+    apply_method = "pending-reboot"
+  }
+}
+
+resource "aws_db_parameter_group" "mysql5-6-etleap" {
+  name        = "etleap-mysql5-6-${random_id.deployment_random.hex}"
+  description = "MySQL 5.6 with Etleap modifications"
+  family      = "mysql5.6"
 
   parameter {
     name         = "max_allowed_packet"


### PR DESCRIPTION
## Description of the change

Fix MySQL to version 5.6.41 and optional variable to start/destroy app, to allow programatically updates
After merge should be module version 1.1.1

New options:
- **rds_allow_major_version_upgrade:** Indicates that major version upgrades are allowed and if an update is required it will be applied immediately
- **app_available:** Enable or disable to start or destroy the app instance. This allows the customer to stop the application before upgrading the RDS DB

## Type of change
- [x] Infrastructure change

## Related story in Pivotal

[terraform-aws-etleap-vpc with upgraded MySQL 5.7](https://www.pivotaltracker.com/story/show/179105166)

## Checklists

### Development

N/A

### Code review 

- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached.
- [x] Reviews have been requested.
- [x] Changes have been reviewed and accepted by at least one other engineer.
- [x] The Pivotal story has a link to this pull request.
