### PR TITLE
Creating the ALB in the private subnet if public access is disabled

### DIFF
--- a/app.tf
+++ b/app.tf
@@ -116,7 +116,7 @@ resource "aws_lb" "app" {
   name_prefix        = "etleap"
   internal           = !var.enable_public_access
   load_balancer_type = "application"
-  subnets            = [local.subnet_a_public_id, local.subnet_b_public_id]
+  subnets            = var.enable_public_access ? [local.subnet_a_public_id, local.subnet_b_public_id] : [local.subnet_a_private_id, local.subnet_b_private_id]
   security_groups    = [aws_security_group.app.id]
 }
 


### PR DESCRIPTION
## Creating the ALB in the private subnet if public access is disabled

Also validated that this doesn't negatively impact any existing deployments. 

## Type of change
- [x] Bug fix (fixes an issue)

## Related story in Pivotal

[M* load balancer is in the wrong subnet](https://www.pivotaltracker.com/story/show/179346375)

## Checklists

### Development

N/A

### Code review 

- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached.
- [x] Reviews have been requested.
- [ ] Changes have been reviewed and accepted by at least one other engineer.
- [x] The Pivotal story has a link to this pull request.
