### PR TITLE
Enable automatic version upgrades for DMS instances - VPC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,6 @@
 
 This changes the DMS replication instance from a specific engine version to being automatically updated before deprecation.
 
-
 # Release 1.13.12
 
 Resolves a rare issue where EMR disks would fill up due to memory heap dumps, by removing excess memory heap dumps regularly.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# Release 1.13.12
+
+Resolves a rare issue where EMR disks would fill up due to memory heap dumps, by removing excess memory heap dumps regularly.
+
+This upgrade requires replacement of the EMR cluster, which will cause 10-15 minutes of downtime to pipelines. The API and Web UI will be unaffected.
+
 # Release 1.13.11
 
 Upgrades dbt from version 1.9, which has reached end of life, to version 1.10.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Release 1.13.13
+
+This changes the DMS replication instance from a specific engine version to being automatically updated before deprecation.
+
+
 # Release 1.13.12
 
 Resolves a rare issue where EMR disks would fill up due to memory heap dumps, by removing excess memory heap dumps regularly.

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Note: This deployment requires Amazon Timestream for InfluxDB to be available in
 ```
 module "etleap" {
   source  = "etleap/etleap-vpc/aws"
-  version = "1.13.12"
+  version = "1.13.13"
 
   deployment_id    = "deployment" # This will be provided by Etleap
   vpc_cidr_block_1 = 172

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Note: This deployment requires Amazon Timestream for InfluxDB to be available in
 ```
 module "etleap" {
   source  = "etleap/etleap-vpc/aws"
-  version = "1.13.11"
+  version = "1.13.12"
 
   deployment_id    = "deployment" # This will be provided by Etleap
   vpc_cidr_block_1 = 172

--- a/dms.tf
+++ b/dms.tf
@@ -2,9 +2,10 @@ resource "aws_dms_replication_instance" "dms" {
   count                        = var.disable_cdc_support ? 0 : 1
   tags                         = merge({Name = "Etleap DMS ${var.deployment_id}"}, local.default_tags)
   replication_instance_class   = var.dms_instance_type
-  engine_version               = "3.5.3"
   allocated_storage            = 250
   apply_immediately            = true
+  auto_minor_version_upgrade   = true
+  allow_major_version_upgrade  = true
   preferred_maintenance_window = "sun:10:30-sun:14:30"
   replication_instance_id      = "etleap-dms${local.resource_name_suffix}"
   replication_subnet_group_id  = aws_dms_replication_subnet_group.dms[0].id

--- a/emr.tf
+++ b/emr.tf
@@ -42,6 +42,10 @@ locals {
     {
       name = "Install DBT"
       path = "s3://etleap-emr-${local.region}/conf-hadoop2/install-dbt-v3.sh"
+    },
+    {
+      name = "Reglarly clean up EMR heap dumps"
+      path = "s3://etleap-emr-${local.region}/clean-java-heap-dumps.sh"
     }
   ]
 


### PR DESCRIPTION
## Description of the change

Same as for hosted - https://github.com/etleap/etleap/pull/11627

[Versions](https://docs.aws.amazon.com/dms/latest/userguide/CHAP_ReleaseNotes.html) get deprecated quite quickly. We're switching to automatic upgrades to make this less work for ourselves and our users.

Our application is already resilient to upgrades. This was tested in [#10125](https://github.com/etleap/etleap/pull/10125) by manually upgrading the DMS instance. This caused no issues or downtime for Etleap.

I tested in a test VPC and this change DOES NOT upgrade from 3.5.3 to 3.5.4 currently as of 12/16/2025.

I will not merge this until both approved and already deployed on hosted + monitored on hosted.

On `hosted`, the change applied correctly and DMS is still on `3.5.3` as expected:
<img width="1695" height="959" alt="image" src="https://github.com/user-attachments/assets/4082416d-6b7c-4de7-82b4-247988ca0430" />


## Type of change
- [ ] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)
- [x] Infrastructure change

## Checklists

### Development

- [x] Validated working in a test VPC.
- [x] Validated that any new resources follow the [naming conventions](https://www.notion.so/etleap/Evolving-the-Terraform-VPC-Module-52f081d09ded4d9291af8c9f8b32a7b2?pvs=4#89d4637048264ddf89803d0815cc4207).
- [x] `CHANGELOG.md` has been updated.
- [x] `README.md` has been updated with the new version; variables and outputs has been added/updated if needed.

### Code review 

- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached.
- [ ] Reviews have been requested.
- [ ] Changes have been reviewed and accepted by at least one other engineer.
- [ ] `CHANGELOG.md` as well as variables, alarms, and readmes have been [reviewed by the PM](https://www.notion.so/etleap/Dev-Workflow-Checklist-1693ed0f162040e8b4659e90ba85252b?pvs=4#8bc0f53b03f34194a46a3df51f551e14).
- [x] The Linear story has a link to this pull request.
