### PR TITLE
Add a EMR Step to stop the yarn timeline server explicitly

### DIFF
--- a/emr.tf
+++ b/emr.tf
@@ -351,6 +351,19 @@ resource "aws_emr_cluster" "emr" {
     }
   }
 
+  # We don't use the YARN Timeline Service, but EMR starts the hadoop-yarn-timelineserver
+  # daemon regardless of "yarn.timeline-service.enabled": "false" (that flag only stops
+  # clients writing to it). It has been observed leaking memory on the master until the node
+  # OOMs (VIK-7860). It only runs on the master, where steps run, so stop and disable it here.
+  step {
+    action_on_failure = "CONTINUE"
+    name = "Disable YARN Timeline Service"
+    hadoop_jar_step {
+      jar = "command-runner.jar"
+      args = ["bash", "-c", "sudo systemctl stop hadoop-yarn-timelineserver; sudo systemctl disable hadoop-yarn-timelineserver"]
+    }
+  }
+
   configurations_json = <<EOF
   [
     {


### PR DESCRIPTION
## Description of the change

The Yarn Timeline server, a service we do not use, has a memory leak. It would get started by EMR even though we do not write to it. 
We explicitly shut the server off after EMR starts off so that the memory leak does not bring down EMRs in VPCs.

## Type of change
- [x] Bug fix (fixes an issue)

## Checklists

### Development

- [ ] Validated working in a test VPC.
- N/A Validated that any new resources follow the [naming conventions](https://www.notion.so/etleap/Evolving-the-Terraform-VPC-Module-52f081d09ded4d9291af8c9f8b32a7b2?pvs=4#89d4637048264ddf89803d0815cc4207).
- [ ] `CHANGELOG.md` has been updated.
- [ ] `README.md` has been updated with the new version; variables and outputs has been added/updated if needed.

### Code review 

- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached.
- [ ] Reviews have been requested.
- [ ] Changes have been reviewed and accepted by at least one other engineer.
- [ ] `CHANGELOG.md` as well as variables, alarms, and readmes have been [reviewed by the PM](https://www.notion.so/etleap/Dev-Workflow-Checklist-1693ed0f162040e8b4659e90ba85252b?pvs=4#8bc0f53b03f34194a46a3df51f551e14).
- [x] The Linear story has a link to this pull request.
